### PR TITLE
Fix for additionalImageLinks field

### DIFF
--- a/google_shop/data/data.xml
+++ b/google_shop/data/data.xml
@@ -40,6 +40,12 @@
             <field name="required">True</field>
             <field name="is_link_field">True</field>
         </record>
+        <record id="google_fields_23" model="google.fields">
+            <field name="name">additionalImageLinks</field>
+            <field name="required">False</field>
+            <field name="is_link_field">True</field>
+            <field name="field_type">list</field>
+        </record>
         <record id="google_fields_8" model="google.fields">
             <field name="name">availability</field>
             <field name="required">True</field>
@@ -175,6 +181,12 @@
 
         <record id="field_mapping_line_5" model="field.mapping.line">
             <field name="google_field_id" ref="google_fields_5"/>
+            <field name="field_mapping_id" ref="field_mapping_1"/>
+            <field name="fixed_text">none</field>
+        </record>
+
+        <record id="field_mapping_line_14" model="field.mapping.line">
+            <field name="google_field_id" ref="google_fields_23"/>
             <field name="field_mapping_id" ref="field_mapping_1"/>
             <field name="fixed_text">none</field>
         </record>

--- a/google_shop/models/google_shop.py
+++ b/google_shop/models/google_shop.py
@@ -538,6 +538,15 @@ class GoogleMerchantShop(models.Model):
         if field_name == "imageLink":
             product['imageLink'] = "%s/web/image/product.product/%s/image_1024" % (
                     base_url, product_id.id)
+        elif field_name == "additionalImageLinks":
+            images = self.env['product.image'].search([
+                ('product_tmpl_id', '=', product_id.product_tmpl_id.id)
+            ])
+            if images:
+                product['additionalImageLinks'] = [
+                    "%s/web/image/product.image/%s/image_1024" % (base_url, img.id)
+                    for img in images
+                ]
         elif field_name == "link":
             
             product['shipping'] = [


### PR DESCRIPTION
## Summary
- support Google `additionalImageLinks` field in field mapping
- expose this in the XML data
- map list of extra product images during export

## Testing
- `python -m py_compile google_shop/models/google_shop.py`

------
https://chatgpt.com/codex/tasks/task_e_68824bf37a748324a330bc5972651471