### PR TITLE
Display additional images in product mapping

### DIFF
--- a/google_shop/views/product_mapping_view.xml
+++ b/google_shop/views/product_mapping_view.xml
@@ -56,6 +56,11 @@
                                 <field name="wk_fetched_issues" readonly="True"/>
                             </group>
                         </page>
+                        <page string="Additional Images">
+                            <group>
+                                <field name="additional_images" readonly="True" nolabel="1"/>
+                            </group>
+                        </page>
                     </notebook>
                 </sheet>
             </form>


### PR DESCRIPTION
## Summary
- compute `additional_images` HTML in product mapping
- show the additional images in a new notebook page

## Testing
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68879afc00388324b810d0f7336a06f3