### PR TITLE
Add Description tab and bold link label

### DIFF
--- a/google_shop/models/product_mapping.py
+++ b/google_shop/models/product_mapping.py
@@ -54,6 +54,8 @@ class ProductMapping(models.Model):
     additional_images = fields.Html(string='Additional Images', compute='_compute_additional_images', readonly=True)
     product_shop_link = fields.Char(string='Google Product Link',
         compute='_compute_product_shop_link', readonly=True)
+    google_description = fields.Text(string='Google Description',
+        compute='_compute_google_description', readonly=True)
     content_language = fields.Many2one(string="Content Language", comodel_name="res.lang",
                                        required=True)
     target_country = fields.Many2one(string="Country", comodel_name="res.country",
@@ -206,3 +208,11 @@ class ProductMapping(models.Model):
                 'target': 'new',
             }
         return False
+
+    @api.depends('product_id')
+    def _compute_google_description(self):
+        for rec in self:
+            desc = ''
+            if rec.product_id:
+                desc = rec.product_id.website_meta_description or ''
+            rec.google_description = desc

--- a/google_shop/views/product_mapping_view.xml
+++ b/google_shop/views/product_mapping_view.xml
@@ -31,8 +31,11 @@
                             <field name="google_product_id" />
                             <field name="message"/>
                             <field name="id" invisible="1"/>
-                            <field name="product_shop_link" readonly="1"/>
-                            <button name="action_open_product_shop_link" type="object" string="Open Link" class="btn-primary" attrs="{'invisible': [('product_shop_link','=',False)]}"/>
+                            <label class="o_form_label" for="product_shop_link" style="font-weight:bold;">Google Product Link</label>
+                            <span class="pt-2">
+                                <field name="product_shop_link" readonly="1" nolabel="1"/>
+                                <button name="action_open_product_shop_link" type="object" string="Open Link" class="btn-primary" attrs="{'invisible': [('product_shop_link','=',False)]}"/>
+                            </span>
                         </group>
                     </group>
                     <notebook>
@@ -56,6 +59,11 @@
                         <page string="Item Level Issues">
                             <group>
                                 <field name="wk_fetched_issues" readonly="True"/>
+                            </group>
+                        </page>
+                        <page string="Description">
+                            <group>
+                                <field name="google_description" readonly="True" nolabel="1"/>
                             </group>
                         </page>
                         <page string="Additional Images">


### PR DESCRIPTION
## Summary
- show the Google Product Link label in bold
- add computed field to hold the exported description
- display the description in a new tab before Additional Images

## Testing
- `python3 -m py_compile google_shop/models/product_mapping.py`

------
https://chatgpt.com/codex/tasks/task_e_6887a30c23888324a097102cb2cc58ce