### PR TITLE
Refactor computed fields via inheritance

### DIFF
--- a/google_shop/__manifest__.py
+++ b/google_shop/__manifest__.py
@@ -42,6 +42,7 @@
         'wizard/product_status_views.xml',
         'wizard/debug_wizard_views.xml',
         'views/product_mapping_view.xml',
+        'views/product_mapping_view_inheritance.xml',
         'views/res_config_settings_views.xml',
         'data/cron_data.xml',
     ],

--- a/google_shop/models/__init__.py
+++ b/google_shop/models/__init__.py
@@ -20,6 +20,7 @@ from . import google_fields
 from . import field_mapping
 from . import field_mapping_line
 from . import product_mapping
+from . import product_mapping_inheritance
 from . import product
 from . import res_config_settings
 from . import target_country

--- a/google_shop/models/product_mapping.py
+++ b/google_shop/models/product_mapping.py
@@ -51,11 +51,6 @@ class ProductMapping(models.Model):
     disapproved_countries = fields.Char(string="Disapproved Countries")
     wk_fetched_issues = fields.Html(string="Fetched Issues")
     image_128 = fields.Image(related='product_id.image_128')
-    additional_images = fields.Html(string='Additional Images', compute='_compute_additional_images', readonly=True)
-    product_shop_link = fields.Char(string='Google Product Link',
-        compute='_compute_product_shop_link', readonly=True)
-    google_description = fields.Text(string='Google Description',
-        compute='_compute_google_description', readonly=True)
     content_language = fields.Many2one(string="Content Language", comodel_name="res.lang",
                                        required=True)
     target_country = fields.Many2one(string="Country", comodel_name="res.country",
@@ -176,43 +171,3 @@ class ProductMapping(models.Model):
             result.append((mapping.id, name))
         return result
 
-    @api.depends('product_id')
-    def _compute_additional_images(self):
-        base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
-        for rec in self:
-            html = ''
-            if rec.product_id:
-                images = self.env['product.image'].search([
-                    ('product_tmpl_id', '=', rec.product_id.product_tmpl_id.id)
-                ])
-                for img in images:
-                    html += '<img src="%s/web/image/product.image/%s/image_128" ' \
-                            'style="margin:5px;max-height:128px;"/>' % (base_url, img.id)
-            rec.additional_images = html
-
-    @api.depends('product_id')
-    def _compute_product_shop_link(self):
-        base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
-        for rec in self:
-            url = ''
-            if rec.product_id and rec.product_id.website_url:
-                url = base_url.rstrip('/') + rec.product_id.website_url
-            rec.product_shop_link = url
-
-    def action_open_product_shop_link(self):
-        self.ensure_one()
-        if self.product_shop_link:
-            return {
-                'type': 'ir.actions.act_url',
-                'url': self.product_shop_link,
-                'target': 'new',
-            }
-        return False
-
-    @api.depends('product_id')
-    def _compute_google_description(self):
-        for rec in self:
-            desc = ''
-            if rec.product_id:
-                desc = rec.product_id.website_meta_description or ''
-            rec.google_description = desc

--- a/google_shop/models/product_mapping_inheritance.py
+++ b/google_shop/models/product_mapping_inheritance.py
@@ -1,0 +1,64 @@
+from odoo import models, fields, api
+
+
+class ProductMappingInheritance(models.Model):
+    _inherit = 'product.mapping'
+
+    additional_images = fields.Html(
+        string='Additional Images',
+        compute='_compute_additional_images',
+        readonly=True
+    )
+    product_shop_link = fields.Char(
+        string='Google Product Link',
+        compute='_compute_product_shop_link',
+        readonly=True
+    )
+    google_description = fields.Text(
+        string='Google Description',
+        compute='_compute_google_description',
+        readonly=True
+    )
+
+    @api.depends('product_id')
+    def _compute_additional_images(self):
+        base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
+        for rec in self:
+            html = ''
+            if rec.product_id:
+                images = self.env['product.image'].search([
+                    ('product_tmpl_id', '=', rec.product_id.product_tmpl_id.id)
+                ])
+                for img in images:
+                    html += (
+                        '<img src="%s/web/image/product.image/%s/image_128" '
+                        'style="margin:5px;max-height:128px;"/>'
+                    ) % (base_url, img.id)
+            rec.additional_images = html
+
+    @api.depends('product_id')
+    def _compute_product_shop_link(self):
+        base_url = self.env['ir.config_parameter'].sudo().get_param('web.base.url')
+        for rec in self:
+            url = ''
+            if rec.product_id and rec.product_id.website_url:
+                url = base_url.rstrip('/') + rec.product_id.website_url
+            rec.product_shop_link = url
+
+    def action_open_product_shop_link(self):
+        self.ensure_one()
+        if self.product_shop_link:
+            return {
+                'type': 'ir.actions.act_url',
+                'url': self.product_shop_link,
+                'target': 'new',
+            }
+        return False
+
+    @api.depends('product_id')
+    def _compute_google_description(self):
+        for rec in self:
+            desc = ''
+            if rec.product_id:
+                desc = rec.product_id.website_meta_description or ''
+            rec.google_description = desc

--- a/google_shop/views/product_mapping_view.xml
+++ b/google_shop/views/product_mapping_view.xml
@@ -31,11 +31,6 @@
                             <field name="google_product_id" />
                             <field name="message"/>
                             <field name="id" invisible="1"/>
-                            <label class="o_form_label" for="product_shop_link" style="font-weight:bold;">Google Product Link</label>
-                            <span class="pt-2">
-                                <field name="product_shop_link" readonly="1" nolabel="1"/>
-                                <button name="action_open_product_shop_link" type="object" string="Open Link" class="btn-primary" attrs="{'invisible': [('product_shop_link','=',False)]}"/>
-                            </span>
                         </group>
                     </group>
                     <notebook>
@@ -59,16 +54,6 @@
                         <page string="Item Level Issues">
                             <group>
                                 <field name="wk_fetched_issues" readonly="True"/>
-                            </group>
-                        </page>
-                        <page string="Description">
-                            <group>
-                                <field name="google_description" readonly="True" nolabel="1"/>
-                            </group>
-                        </page>
-                        <page string="Additional Images">
-                            <group>
-                                <field name="additional_images" readonly="True" nolabel="1"/>
                             </group>
                         </page>
                     </notebook>

--- a/google_shop/views/product_mapping_view_inheritance.xml
+++ b/google_shop/views/product_mapping_view_inheritance.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_mapping_form_inherit_links_images" model="ir.ui.view">
+        <field name="name">Product Mapping Form Inherit Links and Images</field>
+        <field name="model">product.mapping</field>
+        <field name="inherit_id" ref="google_shop.product_mapping_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//group/group[2]" position="inside">
+                <label class="o_form_label" for="product_shop_link" style="font-weight:bold;">Google Product Link</label>
+                <span class="pt-2">
+                    <field name="product_shop_link" readonly="1" nolabel="1"/>
+                    <button name="action_open_product_shop_link" type="object" string="Open Link" class="btn-primary" attrs="{'invisible': [('product_shop_link','=',False)]}"/>
+                </span>
+            </xpath>
+            <xpath expr="//notebook" position="inside">
+                <page string="Description">
+                    <group>
+                        <field name="google_description" readonly="True" nolabel="1"/>
+                    </group>
+                </page>
+                <page string="Additional Images">
+                    <group>
+                        <field name="additional_images" readonly="True" nolabel="1"/>
+                    </group>
+                </page>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Summary
- split computed fields from `product_mapping` into a new inheritance model
- update views to use inheritance for these fields
- load the new view from the module manifest

## Testing
- `python -m py_compile models/product_mapping_inheritance.py models/product_mapping.py`

------
https://chatgpt.com/codex/tasks/task_e_6887a6a4990c8324a00a4316bbcfb5ca