### PR TITLE
Show Trafic menu

### DIFF
--- a/google_shop/views/oauth2_detail_view.xml
+++ b/google_shop/views/oauth2_detail_view.xml
@@ -116,6 +116,8 @@
         </record>
         <menuitem name = "Settings" id= "settings" parent="google_market_menu" sequence="98" />
         <menuitem name = "Mapping" id= "mappings_fields" parent="google_market_menu" sequence="50" />
+        <menuitem name="Trafic" id="google_traffic_menu" parent="google_market_menu" sequence="60"/>
+        <menuitem name="Product Trafic" id="product_traffic_menu" parent="google_traffic_menu" action="product_traffic_action" sequence="1"/>
         <menuitem id="google_shop_product_variants" name="Product Variants" action="product.product_normal_action" parent="mappings_fields" sequence="3" />
         <menuitem name= "Account" id= "oauth2_detail_menu" parent="settings" action='oauth2_detail_action' sequence="1"/>
     </data>

--- a/google_shop/views/product_traffic_view_inheritance.xml
+++ b/google_shop/views/product_traffic_view_inheritance.xml
@@ -48,7 +48,5 @@
         <field name="view_id" ref="product_traffic_tree"/>
     </record>
 
-    <menuitem name="Trafic" id="google_traffic_menu" parent="google_market_menu" sequence="60"/>
-    <menuitem name="Product Trafic" id="product_traffic_menu" parent="google_traffic_menu" action="product_traffic_action" sequence="1"/>
     </data>
 </odoo>


### PR DESCRIPTION
## Summary
- move menu item for Product Trafic into main menu XML
- clean up product_traffic view file

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 - <<'EOF'
import xml.etree.ElementTree as ET
for path in ['views/product_traffic_view_inheritance.xml', 'views/oauth2_detail_view.xml']:
    ET.parse(path)
    print(path, 'OK')
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6887e58bf4c08324b186adc12184b82d