### PR TITLE
Implement product mapping log

### DIFF
--- a/google_shop/models/__init__.py
+++ b/google_shop/models/__init__.py
@@ -25,3 +25,4 @@ from . import product
 from . import product_inheritance
 from . import res_config_settings
 from . import target_country
+from . import product_mapping_log

--- a/google_shop/models/google_shop.py
+++ b/google_shop/models/google_shop.py
@@ -283,10 +283,8 @@ class GoogleMerchantShop(models.Model):
                         log_msgs.append(msg)
 
                     if mapping:
-                        messages_html = '<ul class="list-unstyled">' + ''.join(
-                            f'<li>{m}</li>' for m in log_msgs
-                        ) + '</ul>'
-                        mapping.system_messages = messages_html
+                        for m in log_msgs:
+                            mapping.add_log(m, 'export')
             else:
                 self.shop_status = "done"
                 message = "Well, it seems like your data is on vacation in the Land of Nowhere and having a grand old time sunbathing on the beaches of <b>No Information Island! </b>"
@@ -428,7 +426,12 @@ class GoogleMerchantShop(models.Model):
                     else:
                         self.shop_status = "error"
                         product_id = self.env['product.product'].search([('default_code', '=', response.get("product").get("offerId"))]).id
-                        mapping = self.env['product.mapping'].search([('product_id.id', '=', product_id), ('google_shop_id', '=', self.id,('content_language', '=', content_language), ('target_country', '=', target_country))])
+                        mapping = self.env['product.mapping'].search([
+                            ('product_id.id', '=', product_id),
+                            ('google_shop_id', '=', self.id),
+                            ('content_language', '=', content_language),
+                            ('target_country', '=', target_country),
+                        ])
                         if mapping:
                             mapping.write({
                                 'update_status': False,
@@ -439,10 +442,8 @@ class GoogleMerchantShop(models.Model):
                         log_msgs.append(response['errors']['message'])
 
                     if mapping:
-                        messages_html = '<ul class="list-unstyled">' + ''.join(
-                            f'<li>{m}</li>' for m in log_msgs
-                        ) + '</ul>'
-                        mapping.system_messages = messages_html
+                        for m in log_msgs:
+                            mapping.add_log(m, 'update')
             else:
                 self.shop_status = "done"
                 message = "There is nothing to update"

--- a/google_shop/models/product_inheritance.py
+++ b/google_shop/models/product_inheritance.py
@@ -88,9 +88,7 @@ class ProductGoogleMultiImageBatch(models.Model):
             limit=1,
         )
         if mapping:
-            messages_html = '<ul class="list-unstyled">' + ''.join(
-                f'<li>{m}</li>' for m in image_logs
-            ) + '</ul>'
-            mapping.system_messages = messages_html
+            for log in image_logs:
+                mapping.add_log(log, 'image')
 
         return {'image_ids': image_ids, 'logs': image_logs}

--- a/google_shop/models/product_mapping.py
+++ b/google_shop/models/product_mapping.py
@@ -56,6 +56,21 @@ class ProductMapping(models.Model):
     target_country = fields.Many2one(string="Country", comodel_name="res.country",
                                      required=True)
 
+    log_ids = fields.One2many(
+        comodel_name='product.mapping.log',
+        inverse_name='mapping_id',
+        string='System Message Logs'
+    )
+
+    def add_log(self, message, operation=None):
+        """Create a log record for the current mapping"""
+        for rec in self:
+            self.env['product.mapping.log'].create({
+                'mapping_id': rec.id,
+                'message': message,
+                'operation': operation,
+            })
+
 
     #=== CRUD METHODS ===#
 

--- a/google_shop/models/product_mapping_inheritance.py
+++ b/google_shop/models/product_mapping_inheritance.py
@@ -49,7 +49,11 @@ class ProductMappingInheritance(models.Model):
         compute='_compute_google_traffic',
         readonly=True
     )
-    system_messages = fields.Html(string='System Messages')
+    system_messages = fields.Html(
+        string='System Messages',
+        compute='_compute_system_messages',
+        readonly=True
+    )
 
     @api.depends('product_id')
     def _compute_additional_images(self):
@@ -148,3 +152,10 @@ class ProductMappingInheritance(models.Model):
             rec.google_clicks = clicks
             rec.google_impressions = impressions
             rec.google_ctr = ctr
+
+    def _compute_system_messages(self):
+        for rec in self:
+            html = '<ul class="list-unstyled">' + ''.join(
+                f'<li>{log.message}</li>' for log in rec.log_ids.sorted('date')
+            ) + '</ul>' if rec.log_ids else ''
+            rec.system_messages = html

--- a/google_shop/models/product_mapping_log.py
+++ b/google_shop/models/product_mapping_log.py
@@ -1,0 +1,14 @@
+from odoo import models, fields
+
+class ProductMappingLog(models.Model):
+    _name = 'product.mapping.log'
+    _description = 'Log for product mapping actions'
+
+    mapping_id = fields.Many2one('product.mapping', required=True, ondelete='cascade')
+    message = fields.Char(required=True)
+    operation = fields.Selection([
+        ('export', 'Export'),
+        ('update', 'Update'),
+        ('image', 'Image')
+    ], string='Operation')
+    date = fields.Datetime(default=fields.Datetime.now)

--- a/google_shop/security/ir.model.access.csv
+++ b/google_shop/security/ir.model.access.csv
@@ -6,6 +6,7 @@ user_field_mapping_user,field_mapping_user,model_field_mapping,google_shop.googl
 user_google_fields_user,google_fields_user,model_google_fields,google_shop.google_shop_user_group,1,1,1,0
 user_google_shop_user,google_shop_user,model_google_shop,google_shop.google_shop_user_group,1,1,1,0
 user_product_mapping_user,product_mapping_user,model_product_mapping,google_shop.google_shop_user_group,1,1,1,1
+user_product_mapping_log_user,product_mapping_log_user,model_product_mapping_log,google_shop.google_shop_user_group,1,0,0,0
 
 
 admin_oauth2_detail_manager,oauth2_detail_Manager,model_oauth2_detail,sales_team.group_sale_manager,1,1,1,1
@@ -14,6 +15,7 @@ admin_field_mapping_manager,field_mapping_Manager,model_field_mapping,sales_team
 admin_google_fields_manager,google_fields_Manager,model_google_fields,sales_team.group_sale_manager,1,1,1,1
 admin_google_shop_manager,google_shop_Manager,model_google_shop,sales_team.group_sale_manager,1,1,1,1
 admin_product_mapping_manager,product_mapping_Manager,model_product_mapping,sales_team.group_sale_manager,1,1,1,1
+admin_product_mapping_log_manager,product_mapping_log_Manager,model_product_mapping_log,sales_team.group_sale_manager,1,1,1,1
 admin_product_update_status_manager,product_update_Manager,model_product_status,sales_team.group_sale_manager,1,1,1,1
 
 admin_google_shop_debug_manager,access_google_shop_debug,model_google_shop_debug,sales_team.group_sale_manager,1,1,1,1


### PR DESCRIPTION
## Summary
- add `product.mapping.log` model to store history
- expose `log_ids` on mapping and helper to create logs
- compute system messages from log history
- fix search domain and replace message writes with log creation
- add access rights for new model

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68892cffbd5c8324b070ecf60fbe556c